### PR TITLE
Add new (?) keywords

### DIFF
--- a/syntax/openscad.vim
+++ b/syntax/openscad.vim
@@ -23,10 +23,10 @@ syn keyword openscadConditional if else
 syn keyword openscadRepeat for intersection_for
 syn keyword openscadInclude include use
 syn keyword openscadCsgKeyword union difference intersection render intersection_for
-syn keyword openscadTransform scale rotate translate mirror multmatrix color minkowski hull linear_extrude rotate_extrude
+syn keyword openscadTransform scale rotate translate mirror multmatrix color minkowski hull projection linear_extrude rotate_extrude
 syn keyword openscadPrimitiveSolid cube sphere cylinder polyhedron surface
 syn keyword openscadPrimitive2D square circle polygon import_dxf
-syn keyword openscadPrimitiveImport import
+syn keyword openscadPrimitiveImport import child children
 
 syn match openscadSpecialVariable "\$[a-zA-Z]\+\>" display
 syn match openscadModifier "^\s*[\*\!\#\%]" display
@@ -48,7 +48,8 @@ syn region openscadVector start="\[" end="\]" transparent fold
 
 syn keyword openscadBuiltin abs acos asin atan atan2 ceil cos exp floor ln log
 syn keyword openscadBuiltin lookup max min pow rands round sign sin sqrt tan
-syn keyword openscadBuiltin str 
+syn keyword openscadBuiltin str len search version version_num
+syn keyword openscadBuiltin dxf_cross dxf_dim
 
 hi def link openscadFunctionDef			Structure
 hi def link openscadFunction			Function


### PR DESCRIPTION
When using your syntax file, I noticed that some constructs (mostly hull()) documented in the OpenSCAD manual are missing. I assume they were not supported at the time this syntax file was created.
