### PR TITLE
Syntax Menu & Formatting Macros

### DIFF
--- a/ftdetect/openscad.vim
+++ b/ftdetect/openscad.vim
@@ -1,1 +1,2 @@
 au BufRead,BufNewFile *.scad    setfiletype openscad
+an 50.80.265 &Syntax.NO.OpenSCAD :cal SetSyn("openscad")<CR>

--- a/ftplugin/openscad.vim
+++ b/ftplugin/openscad.vim
@@ -1,0 +1,14 @@
+" Blatantly stolen from vim74\ftplugin\c.vim
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal fo-=t fo+=croql
+
+" Set 'comments' to format dashed lists in comments.
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+
+" Win32 can filter files in the browse dialog
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+    let b:browsefilter = "OpenSCAD Source Files (*.scad)\t*.scad\n" .
+	  \ "All Files (*.*)\t*.*\n"
+endif

--- a/syntax/openscad.vim
+++ b/syntax/openscad.vim
@@ -83,3 +83,14 @@ inoremap ( ()<Esc>i
 " - Inputting opening curly bracket also inputs closing curly bracket
 "   on the next line.
 inoremap { {<CR>}<Esc>kA
+
+" Blatantly stolen from vim74\syntax\c.vim
+"when wanted, highlight trailing white space
+if exists("openscad_space_errors")
+  if !exists("openscad_no_trail_space_error")
+    syn match	openscadSpaceError	display excludenl "\s\+$"
+  endif
+  if !exists("openscad_no_tab_space_error")
+    syn match	openscadSpaceError	display " \+\t"me=e-1
+  endif
+endif


### PR DESCRIPTION
This patch:
- Remaps ( and { to insert matching brace
- Add OpenSCAD entry to syntax menu
- Filter files in the browse dialog
- Other "theft" from Vim C syntax and ftplugin files
