### PR TITLE
Include numbers and underscores in variable names

### DIFF
--- a/syntax/openscad.vim
+++ b/syntax/openscad.vim
@@ -28,7 +28,7 @@ syn keyword openscadPrimitiveSolid cube sphere cylinder polyhedron surface
 syn keyword openscadPrimitive2D square circle polygon import_dxf text
 syn keyword openscadPrimitiveImport import child children
 
-syn match openscadSpecialVariable "\$[a-zA-Z]\+\>" display
+syn match openscadSpecialVariable "\$[a-zA-Z0-9_]\+\>" display
 syn match openscadModifier "^\s*[\*\!\#\%]" display
 
 syn match openscadNumbers "\<\d\|\.\d" contains=openscadNumber display transparent


### PR DESCRIPTION
The openscad manual page for variables states, that numbers and underscores are also allowed variable names. Reflect this in syntax highlighting.